### PR TITLE
Potential fix for code scanning alert no. 2: SQL query built from user-controlled sources

### DIFF
--- a/Controllers/GoatsController.cs
+++ b/Controllers/GoatsController.cs
@@ -122,7 +122,8 @@ public class GoatsController : ControllerBase
 
         connection.Open();
 
-        using var command = new SqlCommand($"SELECT * FROM Customers WHERE Id={id}", connection);
+        using var command = new SqlCommand("SELECT * FROM Customers WHERE Id=@id", connection);
+        command.Parameters.AddWithValue("@id", id);
 
         using var reader = command.ExecuteReader();
         while (reader.Read())


### PR DESCRIPTION
Potential fix for [https://github.com/Dianatestswo/dotnet-goat-api-latest/security/code-scanning/2](https://github.com/Dianatestswo/dotnet-goat-api-latest/security/code-scanning/2)

To fix the issue, the SQL query should be rewritten to use parameterized queries, which prevent SQL injection by separating the query structure from the user-provided data. This involves replacing the string interpolation with a query that includes a parameter placeholder (e.g., `@id`) and then binding the `id` parameter to the query using `SqlParameter`.

Steps to fix:
1. Replace the string interpolation in the SQL query with a parameterized query using `@id`.
2. Add the `id` parameter to the `SqlCommand` object using `SqlParameter` or `AddWithValue`.
3. Ensure the `id` parameter is properly validated (e.g., checking if it is a valid integer) before executing the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
