### PR TITLE
Potential fix for code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/Controllers/GoatsController.cs
+++ b/Controllers/GoatsController.cs
@@ -118,7 +118,8 @@ public class GoatsController : ControllerBase
 
         // var id = Request.Query["id"];
 
-        _logger.LogInformation($"GetCustomers called with id {id}");
+        var sanitizedId = id?.Replace("\r", "").Replace("\n", "");
+        _logger.LogInformation($"GetCustomers called with id {sanitizedId}");
 
         connection.Open();
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dianatestswo/dotnet-goat-api-latest/security/code-scanning/1](https://github.com/Dianatestswo/dotnet-goat-api-latest/security/code-scanning/1)

To fix the problem, we should sanitize the user input before logging it. Since the log entries are likely written to plain text files, the recommended approach is to remove any newline characters from the user input before including it in the log message. This can be done using `String.Replace` to remove both `\r` and `\n` characters from the `id` string. The change should be made in the `GetCustomerByIdInTheWrongWay` method, specifically on line 121 where the log entry is created. No new imports are required, as `String.Replace` is part of the base .NET library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
